### PR TITLE
Make targets dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
   products: [
     .library(
       name: "Reporting",
+      type: .dynamic,
       targets: [
         Targets.filters,
         Targets.sinks,
@@ -21,18 +22,22 @@ let package = Package(
     ),
     .library(
       name: "Filters",
+      type: .dynamic,
       targets: [Targets.filters]
     ),
     .library(
       name: "Sinks",
+      type: .dynamic,
       targets: [Targets.sinks]
     ),
     .library(
       name: "Installations",
+      type: .dynamic,
       targets: [Targets.installations]
     ),
     .library(
       name: "Recording",
+      type: .dynamic,
       targets: [Targets.recording]
     ),
   ],

--- a/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
+++ b/Sources/KSCrashRecording/include/KSCrashAppStateTracker.h
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 #import <Foundation/Foundation.h>
-#import <KSCrashAppTransitionState.h>
+#import "KSCrashAppTransitionState.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/KSCrashRecording/include/KSCrashRecording.h
+++ b/Sources/KSCrashRecording/include/KSCrashRecording.h
@@ -17,5 +17,8 @@
 #import "KSCrashAppTransitionState.h"
 #import "KSCrashReportFields.h"
 #import "KSCrashRecording.h"
+#import "KSCrashAppStateTracker.h"
+#import "KSCrashC.h"
+#import "KSCrashSignalInfo.h"
 
 #endif /* KSCrashRecording_h */


### PR DESCRIPTION
# Overview
In order to create XCFrameworks using this library, and don't duplicate symbols, we've changed the `Package.swift` to create `dynamic` frameworks. Also, made some fixes necessary to achieve that.