### PR TITLE
Support multiple linkeages

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Filters.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Filters.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Installations.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Installations.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/KSCrash-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/KSCrash-Package.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -74,6 +74,76 @@
                BlueprintIdentifier = "Sinks"
                BuildableName = "Sinks"
                BlueprintName = "Sinks"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Filters-Dynamic"
+               BuildableName = "Filters-Dynamic"
+               BlueprintName = "Filters-Dynamic"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Installations-Dynamic"
+               BuildableName = "Installations-Dynamic"
+               BlueprintName = "Installations-Dynamic"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Recording-Dynamic"
+               BuildableName = "Recording-Dynamic"
+               BlueprintName = "Recording-Dynamic"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Reporting-Dynamic"
+               BuildableName = "Reporting-Dynamic"
+               BlueprintName = "Reporting-Dynamic"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Sinks-Dynamic"
+               BuildableName = "Sinks-Dynamic"
+               BlueprintName = "Sinks-Dynamic"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Recording.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Recording.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Reporting.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Reporting.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Sinks.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Sinks.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,15 @@ let package = Package(
   products: [
     .library(
       name: "Reporting",
+      type: .static,
+      targets: [
+        Targets.filters,
+        Targets.sinks,
+        Targets.installations,
+      ]
+    ),
+    .library(
+      name: "Reporting-Dynamic",
       type: .dynamic,
       targets: [
         Targets.filters,
@@ -22,21 +31,41 @@ let package = Package(
     ),
     .library(
       name: "Filters",
+      type: .static,
+      targets: [Targets.filters]
+    ),
+    .library(
+      name: "Filters-Dynamic",
       type: .dynamic,
       targets: [Targets.filters]
     ),
     .library(
       name: "Sinks",
+      type: .static,
+      targets: [Targets.sinks]
+    ),
+    .library(
+      name: "Sinks-Dynamic",
       type: .dynamic,
       targets: [Targets.sinks]
     ),
     .library(
       name: "Installations",
+      type: .static,
+      targets: [Targets.installations]
+    ),
+    .library(
+      name: "Installations-Dynamic",
       type: .dynamic,
       targets: [Targets.installations]
     ),
     .library(
       name: "Recording",
+      type: .static,
+      targets: [Targets.recording]
+    ),
+    .library(
+      name: "Recording-Dynamic",
       type: .dynamic,
       targets: [Targets.recording]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
   products: [
     .library(
       name: "Reporting",
-      type: .static,
       targets: [
         Targets.filters,
         Targets.sinks,
@@ -31,7 +30,6 @@ let package = Package(
     ),
     .library(
       name: "Filters",
-      type: .static,
       targets: [Targets.filters]
     ),
     .library(
@@ -41,7 +39,6 @@ let package = Package(
     ),
     .library(
       name: "Sinks",
-      type: .static,
       targets: [Targets.sinks]
     ),
     .library(
@@ -51,7 +48,6 @@ let package = Package(
     ),
     .library(
       name: "Installations",
-      type: .static,
       targets: [Targets.installations]
     ),
     .library(
@@ -61,7 +57,6 @@ let package = Package(
     ),
     .library(
       name: "Recording",
-      type: .static,
       targets: [Targets.recording]
     ),
     .library(

--- a/Project.swift
+++ b/Project.swift
@@ -10,7 +10,7 @@ let project = Project(
         .target(
             name: "KSCrashRecording",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "com.embrace.KSCrashRecording",
             sources: ["Sources/KSCrashRecording/**"],
             resources: ["Sources/KSCrashRecording/Resources/PrivacyInfo.xcprivacy"], 
@@ -49,7 +49,7 @@ let project = Project(
         .target(
             name: "KSCrashFilters",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "com.embrace.KSCrashFilters",
             sources: ["Sources/KSCrashFilters/**"],
             resources: ["Sources/KSCrashFilters/Resources/PrivacyInfo.xcprivacy"],
@@ -85,7 +85,7 @@ let project = Project(
         .target(
             name: "KSCrashSinks",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "com.embrace.KSCrashSinks",
             sources: ["Sources/KSCrashSinks/**"],
             resources: ["Sources/KSCrashSinks/Resources/PrivacyInfo.xcprivacy"],
@@ -104,7 +104,7 @@ let project = Project(
         .target(
             name: "KSCrashInstallations",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "com.embrace.KSCrashInstallations",
             sources: ["Sources/KSCrashInstallations/**"],
             resources: ["Sources/KSCrashInstallations/Resources/PrivacyInfo.xcprivacy"],
@@ -140,7 +140,7 @@ let project = Project(
         .target(
             name: "KSCrashRecordingCore",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "com.embrace.KSCrashRecordingCore",
             sources: ["Sources/KSCrashRecordingCore/**"],
             resources: ["Sources/KSCrashRecordingCore/Resources/PrivacyInfo.xcprivacy"],
@@ -181,7 +181,7 @@ let project = Project(
         .target(
             name: "KSCrashReportingCore",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "com.embrace.KSCrashReportingCore",
             sources: ["Sources/KSCrashReportingCore/**"],
             resources: ["Sources/KSCrashReportingCore/Resources/PrivacyInfo.xcprivacy"],
@@ -213,7 +213,7 @@ let project = Project(
         .target(
             name: "KSCrashCore",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "com.embrace.KSCrashCore",
             sources: ["Sources/KSCrashCore/**"],
             resources: ["Sources/KSCrashCore/Resources/PrivacyInfo.xcprivacy"],
@@ -237,7 +237,7 @@ let project = Project(
         .target(
             name: "KSCrashTestTools",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "com.embrace.KSCrashTestTools",
             sources: ["Sources/KSCrashTestTools/**"],
             dependencies: [

--- a/Project.swift
+++ b/Project.swift
@@ -10,7 +10,7 @@ let project = Project(
         .target(
             name: "KSCrashRecording",
             destinations: .iOS,
-            product: .framework,
+            product: .staticLibrary,
             bundleId: "com.embrace.KSCrashRecording",
             sources: ["Sources/KSCrashRecording/**"],
             resources: ["Sources/KSCrashRecording/Resources/PrivacyInfo.xcprivacy"], 
@@ -49,7 +49,7 @@ let project = Project(
         .target(
             name: "KSCrashFilters",
             destinations: .iOS,
-            product: .framework,
+            product: .staticLibrary,
             bundleId: "com.embrace.KSCrashFilters",
             sources: ["Sources/KSCrashFilters/**"],
             resources: ["Sources/KSCrashFilters/Resources/PrivacyInfo.xcprivacy"],
@@ -85,7 +85,7 @@ let project = Project(
         .target(
             name: "KSCrashSinks",
             destinations: .iOS,
-            product: .framework,
+            product: .staticLibrary,
             bundleId: "com.embrace.KSCrashSinks",
             sources: ["Sources/KSCrashSinks/**"],
             resources: ["Sources/KSCrashSinks/Resources/PrivacyInfo.xcprivacy"],
@@ -104,7 +104,7 @@ let project = Project(
         .target(
             name: "KSCrashInstallations",
             destinations: .iOS,
-            product: .framework,
+            product: .staticLibrary,
             bundleId: "com.embrace.KSCrashInstallations",
             sources: ["Sources/KSCrashInstallations/**"],
             resources: ["Sources/KSCrashInstallations/Resources/PrivacyInfo.xcprivacy"],
@@ -140,7 +140,7 @@ let project = Project(
         .target(
             name: "KSCrashRecordingCore",
             destinations: .iOS,
-            product: .framework,
+            product: .staticLibrary,
             bundleId: "com.embrace.KSCrashRecordingCore",
             sources: ["Sources/KSCrashRecordingCore/**"],
             resources: ["Sources/KSCrashRecordingCore/Resources/PrivacyInfo.xcprivacy"],
@@ -181,7 +181,7 @@ let project = Project(
         .target(
             name: "KSCrashReportingCore",
             destinations: .iOS,
-            product: .framework,
+            product: .staticLibrary,
             bundleId: "com.embrace.KSCrashReportingCore",
             sources: ["Sources/KSCrashReportingCore/**"],
             resources: ["Sources/KSCrashReportingCore/Resources/PrivacyInfo.xcprivacy"],
@@ -213,7 +213,7 @@ let project = Project(
         .target(
             name: "KSCrashCore",
             destinations: .iOS,
-            product: .framework,
+            product: .staticLibrary,
             bundleId: "com.embrace.KSCrashCore",
             sources: ["Sources/KSCrashCore/**"],
             resources: ["Sources/KSCrashCore/Resources/PrivacyInfo.xcprivacy"],
@@ -237,7 +237,7 @@ let project = Project(
         .target(
             name: "KSCrashTestTools",
             destinations: .iOS,
-            product: .framework,
+            product: .staticLibrary,
             bundleId: "com.embrace.KSCrashTestTools",
             sources: ["Sources/KSCrashTestTools/**"],
             dependencies: [


### PR DESCRIPTION
# Overview
In order to be able to select different types of linkeages for different types of context, we've:
- Removed the `.dynamic` product type from the main products (e.g. `Recording`)
- Created a specific `.dynamic` product for each product we want to expose following the pattern `$PRODUCT_NAME-dynamic`