### PR TITLE
Fix fresh clone build (Tuist) of KSCrashTestTools

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -260,7 +260,8 @@ let project = Project(
             settings: .settings(base: [
                 "SKIP_INSTALL": "NO",
                 "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES",
-                "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/KSCrashCore/include"]
+                "CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER": "NO",
+                "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/KSCrashTestTools/include", "$(SRCROOT)/Sources/KSCrashCore/include"]
             ])
         )
     ]

--- a/Project.swift
+++ b/Project.swift
@@ -255,7 +255,8 @@ let project = Project(
             deploymentTargets: .iOS("13.0"),
             sources: ["Sources/KSCrashTestTools/**"],
             dependencies: [
-                .target(name: "KSCrashRecordingCore")
+                .target(name: "KSCrashRecordingCore"),
+                .xctest
             ],
             settings: .settings(base: [
                 "SKIP_INSTALL": "NO",


### PR DESCRIPTION
On a fresh clone of the repo, building the KSCrashTestTools target with Tuist, in isolation or as part of  a broader 'tuist build',  fails due to missing headers.

Here's how to repro this issue:

![CleanShot 2024-12-17 at 05 39 14@2x](https://github.com/user-attachments/assets/0f10e520-1bc3-4fab-a813-6a252e074541)

Fix:
1. Add the missing KSCrashTestTools/include header search path
2. Add explicit .xctest dependency since Tuist is not auto detecting it successfully